### PR TITLE
ops: fix Docker stack (API, AI, and Web containers + Makefile improvements)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,16 @@
+# Simple placeholder for the web frontend
+FROM node:18-slim
+
+WORKDIR /app
+
+# Copy everything into the container
+COPY . .
+
+# Install dependencies if a package.json exists
+RUN if [ -f package.json ]; then npm install; fi
+
+# Expose the web port
+EXPOSE 3000
+
+# Default command: run a simple static server if no app yet
+CMD [ "npx", "serve", "-s", "." ]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,8 @@
 up:
-	docker compose -f docker-compose.yml up --build
+	docker-compose -f docker-compose.yml up --build
+
 down:
-	docker compose -f docker-compose.yml down -v
+	docker-compose -f docker-compose.yml down -v
+
 logs:
-	docker compose -f docker-compose.yml logs -f
+	docker-compose -f docker-compose.yml logs -f

--- a/services/ai/Dockerfile
+++ b/services/ai/Dockerfile
@@ -1,0 +1,17 @@
+# Simple Python AI service placeholder
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy any AI code (if present)
+COPY . .
+
+# Install dependencies if file exists
+RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+# Expose port for AI service (adjust if different)
+EXPOSE 5055
+
+# Run simple health check app
+CMD ["python3", "main.py"]
+

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,0 +1,16 @@
+# API Service Dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy everything into the container
+COPY . .
+
+# Install dependencies if available
+RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+# Expose the API port
+EXPOSE 8000
+
+# Start the API (FastAPI + Uvicorn)
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
This PR fixes and finalizes the Docker environment for the entire project stack.

- Added missing `Dockerfile` for **services/api**
- Added minimal `Dockerfile` for **services/ai**
- Added placeholder `Dockerfile` for **apps/web**
- Updated `docker/Makefile` to support legacy `docker-compose` v1 (compatibility on Ubuntu)
- Verified that `make up` successfully builds and runs all containers (API, AI, Web, DB)
- Confirmed API responds with `{"status":"ok"}` and other containers run without errors

Test:
```bash
$ make up
# ... build logs ...
$ curl http://localhost:8000/health
{"status":"ok"}
$ curl http://localhost:5055/
{"detail":"Not Found"}
$ curl http://localhost:3000/
<!DOCTYPE html>...
