### PR TITLE
feat(ai): add /chat endpoint + CORS + test_chat (passes locally)

### DIFF
--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -53,3 +53,21 @@ def score(feats: Features):
             "Adjusted with recent win rates (light weight)",
         ],
     )
+
+
+from pydantic import BaseModel
+
+class ChatIn(BaseModel):
+    home_win_pct: float | None = None
+    away_win_pct: float | None = None
+    message: str | None = None
+
+@app.post("/chat")
+def chat(in_: ChatIn):
+    if in_.home_win_pct is not None and in_.away_win_pct is not None:
+        rec = "home" if in_.home_win_pct >= in_.away_win_pct else "away"
+        conf = max(in_.home_win_pct, in_.away_win_pct)
+        reply = f"I’d lean {rec}. Confidence ≈ {conf:.2f}. Reason: higher win%."
+    else:
+        reply = "Send home_win_pct and away_win_pct to get a quick recommendation."
+    return {"reply": reply}

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -3,6 +3,16 @@ from pydantic import BaseModel, Field
 
 app = FastAPI(title="AI Assistant Service", version="0.1.0")
 
+from fastapi.middleware.cors import CORSMiddleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],   # tighten later
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
 # ----- Models -----
 class ScoreRequest(BaseModel):
     home_win_pct: float = Field(..., ge=0.0, le=1.0)
@@ -28,3 +38,21 @@ def score(req: ScoreRequest):
         rec = "away"
         conf = min(max(-diff, 0.0), 1.0)
     return ScoreResponse(recommendation=rec, confidence=conf)
+
+
+from pydantic import BaseModel
+
+class ChatIn(BaseModel):
+    home_win_pct: float | None = None
+    away_win_pct: float | None = None
+    message: str | None = None
+
+@app.post("/chat")
+def chat(in_: ChatIn):
+    if in_.home_win_pct is not None and in_.away_win_pct is not None:
+        rec = "home" if in_.home_win_pct >= in_.away_win_pct else "away"
+        conf = max(in_.home_win_pct, in_.away_win_pct)
+        reply = f"I’d lean {rec}. Confidence ≈ {conf:.2f}. Reason: higher win%."
+    else:
+        reply = "Send home_win_pct and away_win_pct to get a quick recommendation."
+    return {"reply": reply}

--- a/services/ai/tests/test_chat.py
+++ b/services/ai/tests/test_chat.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_chat_reply():
+    r = client.post("/chat", json={"home_win_pct": 0.7, "away_win_pct": 0.3})
+    assert r.status_code == 200
+    assert "lean" in r.json()["reply"].lower()


### PR DESCRIPTION
Adds /chat endpoint to services/ai/main.py (deterministic reply).

Enables CORS for local FE↔AI calls.

Adds services/ai/tests/test_chat.py mirroring test_score.py pattern.

Local proof: pytest -q tests/test_chat.py → 1 passed.

Manual smoke test returns JSON containing “lean”.

Scope: no breaking changes; only AI service touched.