### PR TITLE
ci(api): install dev test deps (pytest, httpx) so TestClient works (F…

### DIFF
--- a/services/api/requirements-dev.txt
+++ b/services/api/requirements-dev.txt
@@ -1,2 +1,5 @@
 pytest==8.3.2
 httpx==0.27.2
+fastapi==0.115.0
+pytest==8.3.2
+httpx==0.27.2


### PR DESCRIPTION
Fixes #23

What:
- Ensure httpx + pytest are installed via requirements-dev.txt in API CI

How to test:
- CI should run API tests green
- Local: cd services/api && python -m venv .venv && . .venv/bin/activate
  pip install -r requirements.txt; pip install -r requirements-dev.txt
  PYTHONPATH=. pytest -q
