### PR TITLE
Feat/api wallet bets

### DIFF
--- a/services/api/routers/bets.py
+++ b/services/api/routers/bets.py
@@ -2,8 +2,11 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Literal
 
-router = APIRouter()
-_BETS: dict[int, dict] = {}   # id -> bet
+# Use a router prefix so inner paths can be "" and "/{bet_id}/cancel"
+router = APIRouter(prefix="/bets", tags=["bets"])
+
+# Simple in-memory store
+_BETS: dict[int, dict] = {}
 _NEXT_ID = 1
 
 class BetCreate(BaseModel):
@@ -20,27 +23,34 @@ class Bet(BaseModel):
     odds: float
     status: Literal["open", "cancelled"]
 
-@router.post("/bets", response_model=Bet)
+@router.post("", response_model=Bet)
 def create_bet(b: BetCreate):
+    # basic validation
     if b.stake <= 0 or b.odds < 1.01:
-        raise HTTPException(422, "invalid bet")
+        raise HTTPException(status_code=422, detail="invalid bet")
     global _NEXT_ID
-    bet = {"id": _NEXT_ID, "match_id": b.match_id, "selection": b.selection,
-           "stake": b.stake, "odds": b.odds, "status": "open"}
+    bet = {
+        "id": _NEXT_ID,
+        "match_id": b.match_id,
+        "selection": b.selection,
+        "stake": b.stake,
+        "odds": b.odds,
+        "status": "open",
+    }
     _BETS[_NEXT_ID] = bet
     _NEXT_ID += 1
     return bet  # type: ignore[return-value]
 
-@router.get("/bets", response_model=list[Bet])
+@router.get("", response_model=list[Bet])
 def list_bets():
     return list(_BETS.values())  # type: ignore[return-value]
 
-@router.post("/bets/{bet_id}/cancel", response_model=Bet)
+@router.post("/{bet_id}/cancel", response_model=Bet)
 def cancel_bet(bet_id: int):
     bet = _BETS.get(bet_id)
     if not bet:
-        raise HTTPException(404, "bet not found")
+        raise HTTPException(status_code=404, detail="bet not found")
     if bet["status"] != "open":
-        raise HTTPException(400, "bet not open")
+        raise HTTPException(status_code=400, detail="bet not open")
     bet["status"] = "cancelled"
     return bet  # type: ignore[return-value]


### PR DESCRIPTION
- /matches, /matches/{id} (UCL-only)
- /odds?match_id=...&league=ucl (moneyline)

### Update (prefix consistency)
- Switched `bets.py` to `APIRouter(prefix="/bets", tags=["bets"])`
- Adjusted routes to inner paths:
  - `@router.post("")` (create)
  - `@router.get("")` (list)
  - `@router.post("/{bet_id}/cancel")` (cancel)
- Endpoint URLs remain unchanged: `/bets`, `/bets/{id}/cancel`.
- Tests still green locally (`pytest -q -k "wallet or bet"`).

## How to test
cd services/api
python3 -m venv .venv && . .venv/bin/activate
pip install -U pip
[ -f requirements.txt ] && pip install -r requirements.txt
[ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || pip install pytest httpx
PYTHONPATH=. pytest -q
deactivate